### PR TITLE
Add ecmwf-api-client to download ECMWF IFS dataset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN apt update && apt install -y wget gpg
 RUN wget -qO - https://patrick-zippenfenig.github.io/ecCodes-ubuntu/public.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/ecCodes-ubuntu.gpg
 RUN echo "deb https://patrick-zippenfenig.github.io/ecCodes-ubuntu/ jammy main" > /etc/apt/sources.list.d/ecCodes-ubuntu.list
 RUN apt update && apt install -y libnetcdf19 libeccodes0 bzip2 cdo curl python3-pip && rm -rf /var/lib/apt/lists/*
-RUN pip3 install cdsapi
+RUN pip3 install cdsapi ecmwf-api-client


### PR DESCRIPTION
This adds a missing Python dependency that is required when running `openmeteo-api download-era5 ecmwf_ifs ...`.